### PR TITLE
fix: prevent double lane jump on mobile tap

### DIFF
--- a/components/game/McLarenDodgeGame.tsx
+++ b/components/game/McLarenDodgeGame.tsx
@@ -414,8 +414,11 @@ export function McLarenDodgeGame() {
     if (!canvas) return;
     const s = stateRef.current;
 
+    const isTouch = 'changedTouches' in e;
+    if (isTouch) e.preventDefault(); // prevent synthesized click from firing twice
+
     const rect = canvas.getBoundingClientRect();
-    const touch = 'changedTouches' in e ? (e as unknown as TouchEvent).changedTouches[0] : null;
+    const touch = isTouch ? (e as unknown as TouchEvent).changedTouches[0] : null;
     const clientX = touch ? touch.clientX : (e as MouseEvent).clientX;
     const x = clientX - rect.left;
     const W = canvas.width;
@@ -472,7 +475,7 @@ export function McLarenDodgeGame() {
 
     window.addEventListener('keydown', handleKey);
     canvas.addEventListener('click', handleClick as EventListener);
-    canvas.addEventListener('touchstart', handleClick as EventListener, { passive: true });
+    canvas.addEventListener('touchstart', handleClick as EventListener, { passive: false });
 
     return () => {
       cancelAnimationFrame(s.animFrameId);


### PR DESCRIPTION
## Summary
- On mobile, tapping left/right triggered both `touchstart` and a browser-synthesized `click`, calling the lane-change handler twice and skipping the middle lane entirely
- Added `e.preventDefault()` on touch events to suppress the synthetic click
- Changed `passive: true` → `passive: false` on the `touchstart` listener to allow `preventDefault()`

## Test plan
- [ ] On mobile, tap left from the middle lane — car should move one lane to the left (not jump to far left)
- [ ] On mobile, tap right from the middle lane — car should move one lane to the right (not jump to far right)
- [ ] On desktop, keyboard arrow keys and mouse still work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)